### PR TITLE
Use only `csalic` since `alic` might be parent/related airline

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -109,8 +109,8 @@ async function get(icao: string, t: Date): Promise<{list: Flight[], more: boolea
             const tail = flight.acr;
             if (typeof flight.act !== "string" || flight.act === "GRND") continue;
             const type = flight.act;
-            if ((flight.alic ?? flight.csalic ?? null) !== null && typeof (flight.alic ?? flight.csalic) !== "string") continue;
-            const airline = (flight.alic ?? flight.csalic) as string | null;
+            if (flight.csalic !== null && typeof flight.csalic !== "string") continue;
+            const airline = flight.csalic as string | null;
             if ((flight.cs ?? flight.fnic ?? flight.ectlcs) !== null && typeof (flight.cs ?? flight.fnic ?? flight.ectlcs) !== "string") continue;
             const callsign = (flight.cs ?? flight.fnic ?? flight.ectlcs) as string | null;
             if (typeof flight.apdstic !== "string" || typeof flight.apdstla !== "number" || typeof flight.apdstlo !== "number") continue;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -110,7 +110,7 @@ async function get(icao: string, t: Date): Promise<{list: Flight[], more: boolea
             if (typeof flight.act !== "string" || flight.act === "GRND") continue;
             const type = flight.act;
             if (flight.csalic !== null && typeof flight.csalic !== "string") continue;
-            const airline = flight.csalic as string | null;
+            const airline = flight.csalic;
             if ((flight.cs ?? flight.fnic ?? flight.ectlcs) !== null && typeof (flight.cs ?? flight.fnic ?? flight.ectlcs) !== "string") continue;
             const callsign = (flight.cs ?? flight.fnic ?? flight.ectlcs) as string | null;
             if (typeof flight.apdstic !== "string" || typeof flight.apdstla !== "number" || typeof flight.apdstlo !== "number") continue;


### PR DESCRIPTION
For example, `csalic` (call-sign airline ID ICAO) might be `CFE` while `alic` (airline ID ICAO) might be "BAW".