### PR TITLE
Fix bogus traffic and handle special callsigns

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -266,3 +266,16 @@ export const PHONETIC = {
     Y: "Yankee",
     Z: "Zulu",
 } as const;
+
+export const NUMBERS = {
+    0: "Zero",
+    1: "One",
+    2: "Two",
+    3: "Three",
+    4: "Four",
+    5: "Five",
+    6: "Six",
+    7: "Seven",
+    8: "Eight",
+    9: "Niner",
+} as const;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,7 @@ import path from "node:path";
 import url from "node:url";
 import fs from "node:fs/promises";
 import {Command} from "commander";
-import {Flight, Location, Direction, PHONETIC} from "./api.js";
+import {Flight, Location, Direction, PHONETIC, NUMBERS} from "./api.js";
 
 const PATH = path.dirname(url.fileURLToPath(import.meta.url));
 
@@ -346,6 +346,20 @@ program.command("gen")
                        new Location(flight.from.name, flight.from.lat, flight.from.lon),
                    ));
                }
+
+               // if there is an airline and the callsign start with more than 3 letters
+               else if (flight.callsign !== null && /^[A-Z]{4,}/.test(flight.callsign.toUpperCase())) {
+                   flights.set(id, new Flight(
+                       flight.id,
+                       flight.time,
+                       flight.tail,
+                       flight.type,
+                       flight.callsign.toUpperCase().replace(/[^A-Z\d]/g, "") + "-",
+                       flight.callsign,
+                       flight.to,
+                       flight.from,
+                   ));
+               }
            }
 
            const merged: {
@@ -372,12 +386,20 @@ program.command("gen")
                    existing.direction.add(direction);
                }
                else {
-                   const pronunciation = flight.airline === null || flight.airline.includes("-")
-                       ? null
-                       : callsigns.get(flight.airline.toUpperCase())
-                       ?? flight.airline.toUpperCase().split("")
-                           .map(c => PHONETIC[c as keyof typeof PHONETIC] ?? c).join(" ");
-                   if (pronunciation !== null && !Array.from(callsigns.values()).includes(pronunciation))
+                   let pronunciation: string | null;
+                   if (flight.airline !== null && flight.airline.endsWith("-")) {
+                       pronunciation = flight.airline.slice(0, -1);
+                       for (const [number, value] of Object.entries(NUMBERS))
+                           pronunciation = pronunciation.replaceAll(number, ` ${value} `);
+                       pronunciation = pronunciation.trim().replace(/\s+/g, " ").toLowerCase();
+                   }
+                   else if (flight.airline === null || flight.airline.includes("-"))
+                       pronunciation = null;
+                   else
+                       pronunciation = callsigns.get(flight.airline.toUpperCase())
+                           ?? flight.airline.toUpperCase().split("")
+                               .map(c => PHONETIC[c as keyof typeof PHONETIC] ?? c).join(" ");
+                   if (pronunciation !== null && !flight.airline?.endsWith("-") && !Array.from(callsigns.values()).includes(pronunciation))
                        process.stderr.write(`WARNING! ${flight.airline}: no pronunciation available\n`);
                    merged.push({
                        airline: flight.airline!,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -108,7 +108,7 @@ async function get(icao: string, t: Date): Promise<{list: Flight[], more: boolea
             const time = new Date((flight.arrau ?? flight.arreu ?? flight.arrsu ?? flight.arrsts) as number * 1000);
             if (flight.acr !== null && typeof flight.acr !== "string") continue;
             const tail = flight.acr;
-            if (typeof flight.act !== "string" || flight.act === "GRND") continue;
+            if (typeof flight.act !== "string" || flight.act === "GRND" || flight.act.toLowerCase() === "zzzz") continue;
             const type = flight.act;
             if (flight.csalic !== null && flight.csalic !== undefined && typeof flight.csalic !== "string") continue;
             const airline = flight.csalic ?? null;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -110,8 +110,11 @@ async function get(icao: string, t: Date): Promise<{list: Flight[], more: boolea
             const tail = flight.acr;
             if (typeof flight.act !== "string" || flight.act === "GRND" || flight.act.toLowerCase() === "zzzz") continue;
             const type = flight.act;
-            if (flight.csalic !== null && flight.csalic !== undefined && typeof flight.csalic !== "string") continue;
-            const airline = flight.csalic ?? null;
+            if (
+                ((flight.csalic === undefined ? flight.alic : flight.csalic) ?? null) !== null
+                && typeof (flight.csalic === undefined ? flight.alic : flight.csalic) !== "string"
+            ) continue;
+            const airline = ((flight.csalic === undefined ? flight.alic : flight.csalic) ?? null) as string | null;
             if ((flight.cs ?? flight.fnic ?? flight.ectlcs) !== null && typeof (flight.cs ?? flight.fnic ?? flight.ectlcs) !== "string") continue;
             const callsign = (flight.cs ?? flight.fnic ?? flight.ectlcs) as string | null;
             if (typeof flight.apdstic !== "string" || typeof flight.apdstla !== "number" || typeof flight.apdstlo !== "number") continue;


### PR DESCRIPTION
- Traffic with ICAO type `ZZZZ` will be ignored. Type is either not available from ADS-B or this is an experimental/uncertified aircraft.
- Aircraft with special callsigns that start with more than 3 letters (e.g. `GECKO82`) are now recorded as such, e.g. `GECKO82-, 0.02, be20, gecko eight two, s`
- Added fallback for airline callsign detection which should help identify the airline in some edge cases.