### PR TITLE
Update callsigns.json

### DIFF
--- a/data/callsigns.json
+++ b/data/callsigns.json
@@ -5458,7 +5458,7 @@
   "WHY": "Air Sorel",
   "WIA": "Windward",
   "WID": "Widgeon",
-  "WIF": "Wideroe",
+  "WIF": "Widerøe",
   "WIG": "Wiggins Airways",
   "WIN": "Teme Airlines",
   "WIS": "Wiscair",


### PR DESCRIPTION
Widerøe's callsign should include the letter `Ø`. Not only is it the correct spelling, but it also makes in-game TTS pronunciation more accurate.