### PR TITLE
Added option to fetch older flights with AirNav Radar subscription

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -111,8 +111,9 @@ async function get(icao: string, t: Date, ua?: string, cf?: string, session?: st
             res.status === 403
             && res.headers.get("content-type") !== "application/json"
         )
-            console.log("\r\n\x1b[0;33mYou are likely facing a Cloudflare challenge. Please see \x1b[1;33m\x1b]8;;https://github.com/zefir-git/eatc-airlines/pull/52#issue-3145483139\x1b\\#52\x1b]8;;\x1b\\\x1b[0;33m on how to resolve it.\x1b[0m");
-        throw new Error(`API returned ${res.status} (${res.statusText}) for ${url}`);
+            console.warn("\r\n\x1b[0;33mYou are likely facing a Cloudflare challenge. Please see \x1b[1;33m\x1b]8;;https://github.com/zefir-git/eatc-airlines/pull/52#issue-3145483139\x1b\\#52\x1b]8;;\x1b\\\x1b[0;33m on how to resolve it.\x1b[0m");
+        console.error(new Error(`API returned ${res.status} (${res.statusText}) for ${url}`));
+        process.exit(1);
     }
     const body = await res.text();
     try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -325,6 +325,7 @@ program.command("fetch")
                    await fs.writeFile(location, JSON.stringify(Array.from(flights.values())));
            }
 
+           clearInterval(progressInterval);
            if (options.silent !== true) process.stderr.write("\n");
            process.stdout.write(`Fetched ${flights.size} flight${flights.size === 1 ? "" : "s"}.\nWriting to ${location}…`);
            await finalSave();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -111,7 +111,7 @@ async function get(icao: string, t: Date, ua?: string, cf?: string, session?: st
             res.status === 403
             && res.headers.get("content-type") !== "application/json"
         )
-            console.log("\x1b[0;33mYou are likely facing a Cloudflare challenge. Please see \x1b[1;33m\x1b]8;;https://github.com/zefir-git/eatc-airlines/pull/52#issue-3145483139\x1b\\#52\x1b]8;;\x1b\\\x1b[0;33m on how to resolve it.\x1b[0m");
+            console.log("\r\n\x1b[0;33mYou are likely facing a Cloudflare challenge. Please see \x1b[1;33m\x1b]8;;https://github.com/zefir-git/eatc-airlines/pull/52#issue-3145483139\x1b\\#52\x1b]8;;\x1b\\\x1b[0;33m on how to resolve it.\x1b[0m");
         throw new Error(`API returned ${res.status} (${res.statusText}) for ${url}`);
     }
     const body = await res.text();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -258,7 +258,7 @@ program.command("fetch")
                    const estimated = Math.round(averagePerDay * remainingDays);
                    message = `\r[${timeAgo(started)}] Fetched: ${flights.size} of ${Number.isNaN(estimated) ? "N/A" : (flights.size + estimated)} (estimated).${oldest !== null ? ` Oldest flight: ${oldest.toLocaleDateString( void 0, {day: "numeric", weekday: "short", month: "short", year: "numeric"})}` : ""}`;
                }
-               process.stderr.write(message + " ".repeat(Math.max(0, process.stdout.columns - message.length)));
+               process.stderr.write(message + " ".repeat(Math.max(0, process.stdout.columns - message.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "").length)));
            }
 
            const flights = new Map<number, Flight>();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -106,7 +106,14 @@ async function get(icao: string, t: Date, ua?: string, cf?: string, session?: st
         headers: requestHeaders,
         credentials: "include",
     });
-    if (!res.ok) throw new Error(`API returned ${res.status} (${res.statusText}) for ${url}`);
+    if (!res.ok) {
+        if (
+            res.status === 403
+            && res.headers.get("content-type") !== "application/json"
+        )
+            console.log("\x1b[0;33mYou are likely facing a Cloudflare challenge. Please see \x1b[1;33m\x1b]8;;https://github.com/zefir-git/eatc-airlines/pull/52#issue-3145483139\x1b\\#52\x1b]8;;\x1b\\\x1b[0;33m on how to resolve it.\x1b[0m");
+        throw new Error(`API returned ${res.status} (${res.statusText}) for ${url}`);
+    }
     const body = await res.text();
     try {
         const json: {list: Record<string, string | number | boolean | null>[], hasEarlier: boolean} = JSON.parse(body);


### PR DESCRIPTION
If you have an AirNav Radar account with a [subscription](https://www.airnavradar.com/subscribe) that allows you to see flights history for more than 7 days ago, then (similarly to #52) you can specify your `rb_session` cookie using the `-S, --session` option when fetching flights.

Because you can fetch more flights (which also takes longer), when fetching to a JSON file, the tool will now periodically save the fetched flights to prevent data loss in the event of an error. Sending ^C will also first save the flights before exiting.

---

<sub>This software is neither affiliated with, nor endorsed by AirNav Radar.</sub>