### PR TITLE
Added HTTP referrer header to fix 403 error

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -94,6 +94,7 @@ async function get(icao: string, t: Date, ua?: string, cf?: string, session?: st
     url.searchParams.set("max", (t.getTime() / 1000).toFixed(0));
 
     const requestHeaders = new Headers();
+    requestHeaders.set("Referer", "https://www.airnavradar.com/data/airports/" + icao);
     if (ua !== undefined)
         requestHeaders.set("User-Agent", ua);
     if (cf !== undefined)


### PR DESCRIPTION
It appears that AirNav Radar no longer needs a Cloudflare cookie and now instead requires the presence of the HTTP `Referer` (intentional misspelling) with any value.

In some cases, you might still have to set the cookie and user agent as per #52.